### PR TITLE
Update spack recipes

### DIFF
--- a/packages/eglrenderer/package.py
+++ b/packages/eglrenderer/package.py
@@ -1,0 +1,45 @@
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack.package import *
+
+import os
+import shutil
+
+class Eglrenderer(CMakePackage):
+    """EGLRender is a lightweight EGL interface for embedded GL rendering
+       with no other dependencies than EGL/OpenGL Intended for on-screen
+       and off-screen GPU rendering with no fancy dependencies.runtime library.
+    """
+    
+    homepage = "https://github.com/carrardt/EGLRender"
+    git = "https://github.com/carrardt/EGLRender.git"
+    
+    # Versions
+    version("main", branch='main', preferred=True)
+    
+    # Variants
+    variant("cuda",     default=False, description="Support for GPU")
+    
+    # Dependencies
+    depends_on("cmake")
+    depends_on("mesa")
+    depends_on("cuda", when="+cuda")
+    
+    default_build_system = "cmake"
+    build_system("cmake", default="cmake")
+    
+    variant(
+        "build_type",
+        default="Release", 
+        values=("Release", "Debug", "RelWithDebInfo"),
+        description="CMake build type",
+    )
+    
+    def cmake_args(self):
+        args = [ self.define_from_variant("EGLRENDER_GPU_COMPUTE_API=CUDA", "cuda"), ]
+        return args
+    
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.prepend_path(
+            'CMAKE_PREFIX_PATH',
+            os.path.join(self.prefix, 'lib', 'cmake')
+        )  

--- a/packages/eglrenderer/package.py
+++ b/packages/eglrenderer/package.py
@@ -35,7 +35,8 @@ class Eglrenderer(CMakePackage):
     )
     
     def cmake_args(self):
-        args = [ self.define_from_variant("EGLRENDER_GPU_COMPUTE_API=CUDA", "cuda"), ]
+        api = "CUDA" if "+cuda" in self.spec else "NONE"
+        args = [ self.define("EGLRENDER_GPU_COMPUTE_API", api), ]
         return args
     
     def setup_dependent_build_environment(self, env, dependent_spec):

--- a/packages/eglrenderer/package.py
+++ b/packages/eglrenderer/package.py
@@ -20,7 +20,7 @@ class Eglrenderer(CMakePackage):
     variant("cuda",     default=False, description="Support for GPU")
     
     # Dependencies
-    depends_on("cmake")
+    depends_on("cmake@3.31.0:")
     depends_on("mesa")
     depends_on("cuda", when="+cuda")
     

--- a/packages/exanbody/package.py
+++ b/packages/exanbody/package.py
@@ -70,13 +70,13 @@ class Exanbody(CMakePackage):
 
     def cmake_args(self):
         args = [
-            self.define_from_variant("EXANB_BUILD_CONTRIB_MD=ON" , "contrib_md" ),
-            self.define_from_variant("EXANB_BUILD_MICROSTAMP=ON" , "contrib_md" ),
-            self.define_from_variant("SNAP_CPU_USE_LOCKS=ON"     , "contrib_md" ),
-            self.define_from_variant("SNAP_FP32_MATH=OFF"        , "contrib_md" ),
-            self.define_from_variant("EXANB_BUILD_CONTRIB_PI=ON" , "contrib_pi" ),
-            self.define_from_variant("EXANB_BUILD_MICROCOSMOS=ON", "contrib_pi" ),
-            self.define_from_variant("EXANB_BUILD_CONTRIB_EGL=ON", "contrib_egl"),
+            self.define_from_variant("EXANB_BUILD_CONTRIB_MD" , "contrib_md" ),
+            self.define_from_variant("EXANB_BUILD_MICROSTAMP" , "contrib_md" ),
+            self.define_from_variant("SNAP_CPU_USE_LOCKS"     , "contrib_md" ),
+            self.define_from_variant("SNAP_FP32_MATH=OFF"     , "contrib_md" ),
+            self.define_from_variant("EXANB_BUILD_CONTRIB_PI" , "contrib_pi" ),
+            self.define_from_variant("EXANB_BUILD_MICROCOSMOS", "contrib_pi" ),
+            self.define_from_variant("EXANB_BUILD_CONTRIB_EGL", "contrib_egl"),
             "-DXNB_PARTICLE_TYPE_INT={0}".format(self.spec.variants['particle_int_type'].value),
               ]
         return args

--- a/packages/exanbody/package.py
+++ b/packages/exanbody/package.py
@@ -26,12 +26,12 @@ class Exanbody(CMakePackage):
     # Variants
     variant("cuda"       , default=False, description="Support for GPU")
     variant("contrib_md" , default=False, description="Support for MD miniapp")
+    variant("snap_fp32"  , default=False, description="Use FP32 math in the SNAP potential (contrib_md)")
     variant("contrib_pi" , default=False, description="Support for PI miniapp")        
     variant("contrib_egl", default=False, description="Support for EGL Rendering")        
 
     # Dependencies
-#    depends_on("cmake@3.27.9")
-    depends_on("cmake")
+    depends_on("cmake@3.31.0:")
     depends_on("yaml-cpp@0.6.3")
     depends_on("openmpi")
     depends_on("cuda", when="+cuda")
@@ -72,8 +72,7 @@ class Exanbody(CMakePackage):
         args = [
             self.define_from_variant("EXANB_BUILD_CONTRIB_MD" , "contrib_md" ),
             self.define_from_variant("EXANB_BUILD_MICROSTAMP" , "contrib_md" ),
-            self.define_from_variant("SNAP_CPU_USE_LOCKS"     , "contrib_md" ),
-            self.define_from_variant("SNAP_FP32_MATH=OFF"     , "contrib_md" ),
+            self.define_from_variant("SNAP_FP32_MATH"         , "snap_fp32"  ),
             self.define_from_variant("EXANB_BUILD_CONTRIB_PI" , "contrib_pi" ),
             self.define_from_variant("EXANB_BUILD_MICROCOSMOS", "contrib_pi" ),
             self.define_from_variant("EXANB_BUILD_CONTRIB_EGL", "contrib_egl"),

--- a/packages/exanbody/package.py
+++ b/packages/exanbody/package.py
@@ -13,6 +13,9 @@ class Exanbody(CMakePackage):
 
     # Versions
     version("main", branch='main')
+    version("v2.1.0",  tag='v2.1.0')
+    version("v2.0.9",  tag='v2.0.9')
+    version("v2.0.8",  tag='v2.0.8')
     version("v2.0.7",  tag='v2.0.7', preferred=True)
     version("v2.0.6",  tag='v2.0.6')
     version("v2.0.5",  tag='v2.0.5')
@@ -21,19 +24,24 @@ class Exanbody(CMakePackage):
     version("v2.0.0",  tag='v2.0.0')
 
     # Variants
-    variant("cuda", default=False, description="Support for GPU")
-    variant("contribs", default=False, description="Support for MD miniapp")    
+    variant("cuda"       , default=False, description="Support for GPU")
+    variant("contrib_md" , default=False, description="Support for MD miniapp")
+    variant("contrib_pi" , default=False, description="Support for PI miniapp")        
+    variant("contrib_egl", default=False, description="Support for EGL Rendering")        
 
     # Dependencies
-    depends_on("cmake@3.27.9")
+#    depends_on("cmake@3.27.9")
+    depends_on("cmake")
     depends_on("yaml-cpp@0.6.3")
     depends_on("openmpi")
     depends_on("cuda", when="+cuda")
+    depends_on("eglrenderer", when="+contrib_egl")
     
     # Main
     depends_on("onika@main", when="@main")
     
     # Versioning
+    depends_on("onika@v1.1.0", when="@v2.1.0")
     depends_on("onika@v1.0.5", when="@v2.0.7")
     depends_on("onika@v1.0.4", when="@v2.0.6")
     depends_on("onika@v1.0.4", when="@v2.0.5")
@@ -61,12 +69,14 @@ class Exanbody(CMakePackage):
         description='Integer type used for field::type')
 
     def cmake_args(self):
-        args = [self.define_from_variant("EXANB_BUILD_CONTRIB_MD=ON", "contribs"),
-            self.define_from_variant("EXANB_BUILD_MICROSTAMP=ON", "contribs"),
-            self.define_from_variant("EXANB_BUILD_CONTRIB_PI=ON", "contribs"),
-            self.define_from_variant("EXANB_BUILD_MICROCOSMOS=ON", "contribs"),
-            self.define_from_variant("SNAP_CPU_USE_LOCKS=ON", "contribs"),
-            self.define_from_variant("SNAP_FP32_MATH=OFF", "contribs"),
+        args = [
+            self.define_from_variant("EXANB_BUILD_CONTRIB_MD=ON" , "contrib_md" ),
+            self.define_from_variant("EXANB_BUILD_MICROSTAMP=ON" , "contrib_md" ),
+            self.define_from_variant("SNAP_CPU_USE_LOCKS=ON"     , "contrib_md" ),
+            self.define_from_variant("SNAP_FP32_MATH=OFF"        , "contrib_md" ),
+            self.define_from_variant("EXANB_BUILD_CONTRIB_PI=ON" , "contrib_pi" ),
+            self.define_from_variant("EXANB_BUILD_MICROCOSMOS=ON", "contrib_pi" ),
+            self.define_from_variant("EXANB_BUILD_CONTRIB_EGL=ON", "contrib_egl"),
             "-DXNB_PARTICLE_TYPE_INT={0}".format(self.spec.variants['particle_int_type'].value),
               ]
         return args

--- a/packages/exastamp/MLIPS_README.md
+++ b/packages/exastamp/MLIPS_README.md
@@ -1,0 +1,129 @@
+# `exastamp +mlips` Spack build — known issues (2026-06-10)
+
+## Symptom
+
+`spack install exastamp+mlips@v3.8.0` fails during the **install** phase
+(not configure, not build):
+
+```
+-- Installing: /pace/cnpy
+CMake Error at src/potential/mlip-pace/pace-mlip/cmake_install.cmake:54 (file):
+  file INSTALL cannot make directory "/pace/cnpy": No such file or directory.
+make: *** [Makefile:113: install] Error 1
+```
+
+The PACE repo clone (done at CMake-configure time by exaStamp's top-level
+`CMakeLists.txt`, into `${CMAKE_BINARY_DIR}/external/pace`) succeeds, and
+`exaStampPace-plugin.so` builds and links fine. The failure is purely in the
+generated install rules for the bundled `cnpy`/`wigner` sub-libs of PACE.
+
+Build log evidence (from
+`/tmp/<user>/spack-stage/spack-stage-exastamp-v3.8.0-<hash>/`):
+- `spack-configure-args.txt` — shows the cmake invocation flags
+- `spack-build-01-cmake-out.txt` — clone happens fine, `Cloning into 'pace'...`
+- `spack-build-03-install-out.txt` — the `/pace/cnpy` error above
+
+## Root cause 1 (blocking) — bug in `Collab4exaNBody/exaStamp_mlip_pace`
+
+In that repo's top-level `CMakeLists.txt`:
+
+```cmake
+## cnpy (always built from bundled source)
+...
+install(DIRECTORY cnpy
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/pace   # <-- CMAKE_INSTALL_INCLUDEDIR is empty here!
+  FILES_MATCHING PATTERN *.h
+)
+
+## wigner-cpp
+...
+install(DIRECTORY wigner
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/pace   # <-- same problem
+  FILES_MATCHING PATTERN *.hpp
+)
+
+...
+include(GNUInstallDirs)   # <-- only defined here, AFTER the two installs above!
+```
+
+`include(GNUInstallDirs)` is called *after* the two `install(DIRECTORY ...)`
+calls that already reference `${CMAKE_INSTALL_INCLUDEDIR}`. On a fresh
+configure, the variable is undefined/empty, so
+`DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/pace` becomes the literal string
+`DESTINATION /pace`. CMake treats a destination starting with `/` as an
+**absolute path** (filesystem root `/pace`), not as relative to
+`CMAKE_INSTALL_PREFIX`. Hence `make install` tries to create `/pace/cnpy`
+and fails (no permission / doesn't exist).
+
+### Fix
+
+Move `include(GNUInstallDirs)` to the very top of
+`exaStamp_mlip_pace/CMakeLists.txt`, right after `project(libpace ...)`,
+before the `install(DIRECTORY cnpy ...)` / `install(DIRECTORY wigner ...)`
+calls.
+
+### Why this never showed up in local/manual builds
+
+- `CMAKE_INSTALL_INCLUDEDIR` is a CACHE variable. Once `include(GNUInstallDirs)`
+  runs once for a build directory, the value (`include`) is written to
+  `CMakeCache.txt` and persists across reconfigures — so on a *reused* local
+  `build/` dir, by the time the buggy lines run again, the cache var is
+  already set and everything resolves correctly (`include/pace`).
+- The bug only manifests in the generated `cmake_install.cmake`, i.e. only
+  if `make install` / `cmake --install` actually runs. Plenty of local dev
+  workflows just run binaries from the build tree and never install.
+- Spack always builds in a brand-new `spack-build-<hash>` directory (empty
+  `CMakeCache.txt`) and **always** runs the install step — so the latent
+  ordering bug is exposed every time.
+
+## Root cause 2 — bug in `packages/exastamp/package.py` (this repo)
+
+`cmake_args()`:
+
+```python
+def cmake_args(self):
+    args = [
+        self.define_from_variant("EXASTAMP_BUILD_PACE=ON", "mlips" ),
+        self.define_from_variant("EXASTAMP_BUILD_POD=ON" , "mlips" ),
+    ]
+    return args
+```
+
+`define_from_variant`'s first argument should just be the CMake variable
+name (e.g. `"EXASTAMP_BUILD_PACE"`). As written, Spack's `define()` produces:
+
+```
+-DEXASTAMP_BUILD_PACE=ON:BOOL=ON   (when +mlips)
+-DEXASTAMP_BUILD_PACE=ON:BOOL=OFF  (when ~mlips)
+```
+
+CMake's `-D` parser splits on the *first* `=`, so this sets cache variable
+`EXASTAMP_BUILD_PACE` to the **string** `"ON:BOOL=ON"` or `"ON:BOOL=OFF"`.
+Neither string is one of CMake's recognized "false" constants
+(`0/OFF/NO/FALSE/N/IGNORE/NOTFOUND/""/*-NOTFOUND`), so
+`if(EXASTAMP_BUILD_PACE)` evaluates **TRUE in both cases** — i.e. the
+`mlips` variant currently has *no effect*: PACE/POD (and the network git
+clone of the private PACE repo) are always attempted, even with `~mlips`.
+
+Confirmed in `spack-configure-args.txt`:
+```
+-DEXASTAMP_BUILD_PACE=ON:BOOL=ON -DEXASTAMP_BUILD_POD=ON:BOOL=ON
+```
+
+### Fix
+
+```python
+def cmake_args(self):
+    return [
+        self.define_from_variant("EXASTAMP_BUILD_PACE", "mlips"),
+        self.define_from_variant("EXASTAMP_BUILD_POD", "mlips"),
+    ]
+```
+
+## TODO
+
+- [ ] Fix `include(GNUInstallDirs)` ordering in `exaStamp_mlip_pace/CMakeLists.txt`
+- [ ] Fix `define_from_variant` calls in `packages/exastamp/package.py`
+- [ ] Re-run `spack install exastamp+mlips@v3.8.0` end to end
+- [ ] Consider `~mlips` build too, to confirm it now actually skips PACE/POD
+      (and the SSH git clone of `exaStamp_mlip_pace`)

--- a/packages/exastamp/package.py
+++ b/packages/exastamp/package.py
@@ -26,7 +26,7 @@ class Exastamp(CMakePackage):
     depends_on("exanbody+cuda", when="+cuda")
 
     # Dependencies
-    depends_on("cmake")
+    depends_on("cmake@3.31.0:")
     depends_on("yaml-cpp@0.6.3")
     depends_on("openmpi")
     
@@ -34,12 +34,12 @@ class Exastamp(CMakePackage):
     depends_on("exanbody@main", when="@main")
 
     # Versioning
-    depends_on("exanbody@v2.1.0", when="@3.8.0")
-    depends_on("exanbody@v2.0.8", when="@3.7.5")    
-    depends_on("exanbody@v2.0.7", when="@3.7.4")
-    depends_on("exanbody@v2.0.6", when="@3.7.3")
-    depends_on("exanbody@v2.0.5", when="@3.7.2")
-    depends_on("exanbody@v2.0.2", when="@3.7.0")    
+    depends_on("exanbody@v2.1.0", when="@v3.8.0")
+    depends_on("exanbody@v2.0.8", when="@v3.7.5")    
+    depends_on("exanbody@v2.0.7", when="@v3.7.4")
+    depends_on("exanbody@v2.0.6", when="@v3.7.3")
+    depends_on("exanbody@v2.0.5", when="@v3.7.2")
+    depends_on("exanbody@v2.0.2", when="@v3.7.0")    
 
     build_system("cmake", default="cmake")
     

--- a/packages/exastamp/package.py
+++ b/packages/exastamp/package.py
@@ -13,18 +13,20 @@ class Exastamp(CMakePackage):
 
     # Versions
     version('main', branch='main')
-    version('3.7.4', branch='v3.7.4', preferred=True)
-    version('3.7.3', branch='v3.7.3')
-    version('3.7.2', branch='v3.7.2')
-    version('3.7.0', branch='v3.7.0-rdev')
-    variant("cuda", default=False, description="Support for GPU")
-
+    version('v3.8.0', branch='v3.8.0', preferred=True)
+    version('v3.7.5', branch='v3.7.5')
+    version('v3.7.4', branch='v3.7.4')
+    version('v3.7.3', branch='v3.7.3')
+    version('v3.7.2', branch='v3.7.2')
+    variant("cuda" , default=False, description="Support for GPU")
+    variant("mlips", default=True , description="Support for MLIPS - POD PACE etc...-")
+    
     # Variants
-    depends_on("exanbody+contribs")
+    depends_on("exanbody+contrib_md")
     depends_on("exanbody+cuda", when="+cuda")
 
     # Dependencies
-    depends_on("cmake@3.27.9")
+    depends_on("cmake")
     depends_on("yaml-cpp@0.6.3")
     depends_on("openmpi")
     
@@ -32,6 +34,8 @@ class Exastamp(CMakePackage):
     depends_on("exanbody@main", when="@main")
 
     # Versioning
+    depends_on("exanbody@v2.1.0", when="@3.8.0")
+    depends_on("exanbody@v2.0.8", when="@3.7.5")    
     depends_on("exanbody@v2.0.7", when="@3.7.4")
     depends_on("exanbody@v2.0.6", when="@3.7.3")
     depends_on("exanbody@v2.0.5", when="@3.7.2")
@@ -43,5 +47,8 @@ class Exastamp(CMakePackage):
         env.set('exaStamp_DIR', self.prefix)
 
     def cmake_args(self):
-        args = [ ]
+        args = [
+            self.define_from_variant("EXASTAMP_BUILD_PACE=ON", "mlips" ),
+            self.define_from_variant("EXASTAMP_BUILD_POD=ON" , "mlips" ),            
+        ]
         return args

--- a/packages/exastamp/package.py
+++ b/packages/exastamp/package.py
@@ -48,7 +48,7 @@ class Exastamp(CMakePackage):
 
     def cmake_args(self):
         args = [
-            self.define_from_variant("EXASTAMP_BUILD_PACE=ON", "mlips" ),
-            self.define_from_variant("EXASTAMP_BUILD_POD=ON" , "mlips" ),            
+            self.define_from_variant("EXASTAMP_BUILD_PACE", "mlips" ),
+            self.define_from_variant("EXASTAMP_BUILD_POD" , "mlips" ),            
         ]
         return args

--- a/packages/exastamp/package.py
+++ b/packages/exastamp/package.py
@@ -19,7 +19,7 @@ class Exastamp(CMakePackage):
     version('v3.7.3', branch='v3.7.3')
     version('v3.7.2', branch='v3.7.2')
     variant("cuda" , default=False, description="Support for GPU")
-    variant("mlips", default=True , description="Support for MLIPS - POD PACE etc...-")
+    variant("mlips", default=False, description="Support for MLIPS - POD PACE etc...-")
     
     # Variants
     depends_on("exanbody+contrib_md")

--- a/packages/onika/package.py
+++ b/packages/onika/package.py
@@ -25,7 +25,7 @@ class Onika(CMakePackage):
     variant("contribs", default=False, description="Support for EGL Rendering")
 
     # Dependencies
-    depends_on("cmake")
+    depends_on("cmake@3.31.0:")
     depends_on("yaml-cpp@0.6.3")
     depends_on("openmpi")
     depends_on("cuda"       , when="+cuda")

--- a/packages/onika/package.py
+++ b/packages/onika/package.py
@@ -13,19 +13,23 @@ class Onika(CMakePackage):
 
     # Versions
     version("main", branch='main')
+    version("v1.1.0",  tag='v1.1.0')
+    version("v1.0.6",  tag='v1.0.6')
     version("v1.0.5",  tag='v1.0.5')
     version("v1.0.4",  tag='v1.0.4', preferred=True)
     version("v1.0.2",  tag='v1.0.2')
     version("v1.0.0",  tag='v1.0.0')
 
     # Variants
-    variant("cuda", default=False, description="Support for GPU")
+    variant("cuda"    , default=False, description="Support for GPU")
+    variant("contribs", default=False, description="Support for EGL Rendering")
 
     # Dependencies
     depends_on("cmake")
     depends_on("yaml-cpp@0.6.3")
     depends_on("openmpi")
-    depends_on("cuda", when="+cuda")
+    depends_on("cuda"       , when="+cuda")
+    depends_on("eglrenderer", when="+contribs")
     
     default_build_system = "cmake"
     build_system("cmake", default="cmake")
@@ -38,5 +42,5 @@ class Onika(CMakePackage):
         )
 
     def cmake_args(self):
-      args = [ self.define_from_variant("ONIKA_BUILD_CUDA", "cuda"), ]
+      args = [ self.define_from_variant("ONIKA_BUILD_CUDA", "cuda"), self.define_from_variant("ONIKA_BUILD_CONTRIBS", "contribs"), ]
       return args


### PR DESCRIPTION
## Modifications : 
1) Add spack recipe for **eglrenderer** frm @carrardt 
2) Update all onika exaNBody exaStamp recipes with latest releases
3) Add **+contribs** variant for onika that depends on eglrenderer
4) Add **+contrib_egl** variant for exaNBody that depends on onika with eglrenderer
5) Renamed variants **contrib_md** (Molecular Dynamics) and **contrib_pi** (Planetary Interactions) for exaNBody
6) Add variant **mlips** for exaStamp with POD + PACE interatomic potential support 